### PR TITLE
fixes recursion in getElement{ById,sByTagName}

### DIFF
--- a/lib/XML.pm6
+++ b/lib/XML.pm6
@@ -733,7 +733,7 @@ class XML::Element does XML::Node
   {
     my %query = 
     {
-      'RECURSE' => 999,      ## don't nest this deep, please?
+      'RECURSE' => Inf,
       'SINGLE'  => True,     ## an id should be unique, first come first serve.
       $.idattr  => $id,      ## the id attribute is configurable.
     };
@@ -744,7 +744,7 @@ class XML::Element does XML::Node
   {
     my %query =
     {
-      'RECURSE' => 999,
+      'RECURSE' => Inf,
       'TAG'     => $name,
       'OBJECT'  => $object,
     };


### PR DESCRIPTION
Fixes getElementById and getElementsByTagName to work no matter how deep the
target element(s) might be in the XML tree.
