### PR TITLE
Fix #54: Can not parse name with a peroids

### DIFF
--- a/lib/XML/Grammar.pm6
+++ b/lib/XML/Grammar.pm6
@@ -84,7 +84,10 @@ regex cdata {
 }
 
 token textnode { <-[<]>+ }
-token pident {
-  <!before \d> [ \d+ <.ident>* || <.ident>+ ]+ % '-'
-}
-token name { <.pident>+ [ ':' <.pident>+ ]? }
+token namestartchar {
+  ":" || <[A..Z]> || "_" || <[a..z]>
+  || <[\xC0..\xD6]> || <[\xD8..\xF6]> || <[\xF8..\x2FF]> || <[\x370..\x37D]> || <[\x37F..\x1FFF]>
+  || <[\x200C..\x200D]> || <[\x2070..\x218F]> || <[\x2C00..\x2FEF]> || <[\x3001..\xD7FF]>
+  || <[\xF900..\xFDCF]> || <[\xFDF0..\xFFFD]> || <[\x10000..\xEFFFF]> }
+token namechar { <namestartchar> ||  "-" || "." || <[0..9]> || \xB7 || <[\x0300..\x036F]> || <[\x203F..\x2040]> }
+token name { <.namestartchar> <.namechar>* }

--- a/t/parser.t
+++ b/t/parser.t
@@ -5,7 +5,7 @@
 use Test;
 use XML;
 
-plan 13;
+plan 14;
 
 my $text = '<test><title>The title</title><bullocks><item name="first"/><item name="second"/></bullocks></test>';
 
@@ -40,6 +40,7 @@ is $xml.root.attribs<attr1>, 'foo', 'got single-quoted attribute';
 
 # Test available identifiers.
 
+lives-ok { from-xml('<name_contain.periods>some text</name_contain.periods>') }, 'valid tag name';
 lives-ok { from-xml('<foo><bar id1-1paté="bat" /></foo>') }, 'valid attribute name';
 dies-ok  { from-xml('<foo><bar 2d="bar" /></foo>') }, 'invalid attribute name';
 


### PR DESCRIPTION
This commit changes `name`, `namechar`, and `namestartchar` to match the XML specification.