### PR TITLE
Extend attribute matching capabilities

### DIFF
--- a/lib/XML/Element.pm6
+++ b/lib/XML/Element.pm6
@@ -462,7 +462,7 @@ class XML::Element does XML::Node
       if $node ~~ XML::Element
       {
         my $matched = True;
-        for %query.kv -> $key, $val
+        for %query.kv -> $key, Mu $val
         {
           if $key eq 'RECURSE' | 'NEST' | 'SINGLE' | 'OBJECT' | 'BYINDEX'
           {
@@ -559,21 +559,11 @@ class XML::Element does XML::Node
           {
             if $val ~~ Bool
             {
-              if $val === True
-              {
-                if $node.attribs{$key}:!exists { $matched = False; last; }
-              }
-              else
-              {
-                if $node.attribs{$key}:exists { $matched = False; last; }
-              }
+              last unless $matched = ($node.attribs{$key}:exists === $val);
             }
             else
             {
-              if $node.attribs{$key}:!exists || $node.attribs{$key} !~~ $val
-              {
-                $matched = False; last;
-              }
+              last unless $matched = ($node.attribs{$key} // Nil) ~~ $val;
             }
           }
         }

--- a/t/query-methods.t
+++ b/t/query-methods.t
@@ -5,7 +5,7 @@
 use Test;
 use XML;
 
-plan 26;
+plan 32;
 
 my $text = slurp('./t/query.xml');
 
@@ -84,3 +84,15 @@ ok $subxml.name eq "a", "The returned element is <a>";
 $subxml = $xml.lookfor(:TAG<a>, :SINGLE);
 ok $subxml ~~ XML::Element, "found an element with lookfor(:TAG<a>, :SINGLE)";
 
+$subxml = $xml.lookfor(:TAG<multi>, :SINGLE);
+@items = $subxml.lookfor(:TAG<option>, :!class);
+is +@items, 1, "found an element with attribute missing";
+is @items[0].attribs<name>, "m2", "no attribute got us proper element";
+
+@items = $subxml.lookfor(:TAG<option>, :class(Nil | "skip"));
+is +@items, 2, "a junction matcher gives us all expected elements";
+is-deeply @items.map(*.attribs<name>).List, <m1 m2>, "only expected elements are given";
+
+@items = $subxml.lookfor(:TAG<option>, :class{ !(.defined && .contains("skip")) });
+is +@items, 2, "a code matcher gives us all expected elements";
+is-deeply @items.map(*.attribs<name>).List, <m2 m3>, "only expected elements are given";

--- a/t/query.xml
+++ b/t/query.xml
@@ -14,4 +14,9 @@
     <a id="hi" href="hello world">hello</a>
     Now it works. Bloody <b>hell</b>.
   </nested>
+  <multi>
+      <option name="m1" class="skip"/>
+      <option name="m2"/>
+      <option name="m3" class="include"/>
+  </multi>
 </test>


### PR DESCRIPTION
Implement full smartmatch semantics for non-boolean and optimize booleans.

The test additions briefly demonstrate what is now possible. But basically whatever smartmatch is capable of is now allowed for the attribute matching.

There is no difference between `:!attribute` and `:attribute(Nil)` outcome, but semantically they're different. The former is an equivalence match, the latter is a smart match.

Fixes #64.